### PR TITLE
Tailwind fix and network dedupe

### DIFF
--- a/app/components/accordion/SbAccordion.tsx
+++ b/app/components/accordion/SbAccordion.tsx
@@ -15,7 +15,7 @@ const SbAccordion: FC<AccordionProps> = ({
   endpoint,
   initialLoadComplete = false, // Default to false
 }) => {
-  let [extraHeight, setExtraHeight] = useState(1000); // Start with 1000px extra
+  let [extraHeight, setExtraHeight] = useState(150); // Start with 1000px extra
   let [openIndexes, setOpenIndexes] = useState<number[]>([]);
   let itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   let [readyToLoad, setReadyToLoad] = useState(initialLoadComplete);

--- a/app/contexts/MediaCacheContext.tsx
+++ b/app/contexts/MediaCacheContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext } from "react";
 
 interface MediaCacheEntry {
   loaded: boolean;
+  loading: boolean; // Add loading state
   error: boolean;
   timestamp: number;
   attempts?: number;
@@ -13,9 +14,18 @@ export const globalMediaCache = new Map<string, MediaCacheEntry>();
 // Context for accessing the cache
 const MediaCacheContext = createContext({
   cache: globalMediaCache,
+  setMediaLoading: (key: string) => {
+    globalMediaCache.set(key, {
+      loaded: false,
+      loading: true,
+      error: false,
+      timestamp: Date.now(),
+    });
+  },
   setMediaLoaded: (key: string) => {
     globalMediaCache.set(key, {
       loaded: true,
+      loading: false,
       error: false,
       timestamp: Date.now(),
     });
@@ -24,6 +34,7 @@ const MediaCacheContext = createContext({
     const existing = globalMediaCache.get(key);
     globalMediaCache.set(key, {
       loaded: false,
+      loading: false,
       error: true,
       timestamp: Date.now(),
       attempts: (existing?.attempts || 0) + 1,
@@ -32,6 +43,10 @@ const MediaCacheContext = createContext({
   isMediaLoaded: (key: string): boolean => {
     const entry = globalMediaCache.get(key);
     return entry?.loaded === true;
+  },
+  isMediaLoading: (key: string): boolean => {
+    const entry = globalMediaCache.get(key);
+    return entry?.loading === true;
   },
   isMediaError: (key: string): boolean => {
     const entry = globalMediaCache.get(key);
@@ -55,9 +70,18 @@ export const MediaCacheProvider: React.FC<{ children: React.ReactNode }> = ({
     <MediaCacheContext.Provider
       value={{
         cache: globalMediaCache,
+        setMediaLoading: (key: string) => {
+          globalMediaCache.set(key, {
+            loaded: false,
+            loading: true,
+            error: false,
+            timestamp: Date.now(),
+          });
+        },
         setMediaLoaded: (key: string) => {
           globalMediaCache.set(key, {
             loaded: true,
+            loading: false,
             error: false,
             timestamp: Date.now(),
           });
@@ -66,6 +90,7 @@ export const MediaCacheProvider: React.FC<{ children: React.ReactNode }> = ({
           const existing = globalMediaCache.get(key);
           globalMediaCache.set(key, {
             loaded: false,
+            loading: false,
             error: true,
             timestamp: Date.now(),
             attempts: (existing?.attempts || 0) + 1,
@@ -74,6 +99,10 @@ export const MediaCacheProvider: React.FC<{ children: React.ReactNode }> = ({
         isMediaLoaded: (key: string): boolean => {
           const entry = globalMediaCache.get(key);
           return entry?.loaded === true;
+        },
+        isMediaLoading: (key: string): boolean => {
+          const entry = globalMediaCache.get(key);
+          return entry?.loading === true;
         },
         isMediaError: (key: string): boolean => {
           const entry = globalMediaCache.get(key);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-router";
 
 import type { Route } from "./+types/root";
-import "./app.css";
+import styles from "./app.css?url";
 import { HeroUIProvider } from "@heroui/react";
 import { getToast } from "remix-toast";
 import { useEffect } from "react";
@@ -22,6 +22,7 @@ import { MediaCacheProvider } from "~/contexts/MediaCacheContext";
 // Add the toast stylesheet
 export const links: Route.LinksFunction = () => [
   { rel: "stylesheet", href: toastStyles },
+  { rel: "stylesheet", href: styles },
   {
     rel: "icon",
     href: "/favicon.svg",
@@ -54,6 +55,11 @@ export default function App({ loaderData }: Route.ComponentProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        {/* <script
+          src="https://embed.laylo.com/laylo-sdk.js"
+          crossOrigin="anonymous"
+          async
+        /> */}
       </head>
       <body className="text-xs md:text-medium">
         <HeroUIProvider>
@@ -81,7 +87,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
       error.status === 404
         ? "The requested page could not be found."
         : error.statusText || details;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
+  } else if (error && error instanceof Error) {
     details = error.message;
     stack = error.stack;
   }

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -22,6 +22,12 @@ export function meta() {
   ];
 }
 
+// export function scripts() {
+//   return [
+//     <script src="https://embed.laylo.com/laylo-sdk.js"></script>
+//   ]
+// }
+
 // NOTE: Revolving banner in the top of the page -- start black and on scroll go and turn white
 export async function loader({}: Route.LoaderArgs) {
   // NOTE: limited to five in each
@@ -127,6 +133,23 @@ export default function ({ loaderData }: Route.ComponentProps) {
         allowMultiple
         initialLoadComplete={initialLoadComplete}
       />
+      {/* <div style={{ backgroundColor: "black" }}>
+        <iframe
+          id="laylo-drop-pIGZH"
+          frameBorder="0"
+          allowTransparency
+          style={{
+            width: "1px",
+            minWidth: "100%",
+            // maxWidth: "1000px",
+            // height: "600px", // Must set a height!
+            border: "none", // Optional for visual polish
+            overflow: "hidden",
+            backgroundColor: "black",
+          }}
+          src="https://embed.laylo.com?dropId=pIGZH&color=0c0c0c&minimal=false&theme=dark&background=solid&customTitle=Get%20notified%20when%20new%20content%20drops"
+        />
+      </div> */}
     </div>
   );
 }


### PR DESCRIPTION
Add App.css to the export links -- should fix the hydration error on root/index page

add logic in thumnail, video viewer, and media cache context to not request the same content all at once but check requests.